### PR TITLE
Axios config

### DIFF
--- a/src/Pinniped.js
+++ b/src/Pinniped.js
@@ -8,11 +8,11 @@ import Data from "./data.js";
 class Pinniped {
   /**
    * Initializes the Pinniped SDK with the provided base URL
-   * @param {string} url - The base URL of the Pinniped server
+   * @param {string} baseURL - The base URL of the Pinniped server
    * @returns {Pinniped} - An instance of the Pinniped SDK
    */
-  static initialize(url) {
-    return new Pinniped(url);
+  static initialize(baseURL) {
+    return new Pinniped(baseURL);
   }
 
   /**
@@ -24,8 +24,9 @@ class Pinniped {
    */
   constructor(baseURL) {
     this.url = baseURL;
-    this.auth = new Auth(baseURL, this.sendRequest);
-    this.db = new Data(baseURL, this.sendRequest);
+    this.axios = axios.create({ withCredentials: true });
+    this.auth = new Auth(this);
+    this.db = new Data(this);
     console.log("Pinniped SDK initialized");
   }
 
@@ -41,17 +42,18 @@ class Pinniped {
     const request = {
       method,
       url: `${this.url}${path}`,
-      headers: {
-        "Content-Type": "application/json",
-      },
       params: queryString,
-      withCredentials: true, // Include cookies in requests
     };
-    if (body) {
-      request.data = body;
+
+    if (body) request.data = body;
+
+    if (["POST", "PATCH", "PUT"].includes(method)) {
+      request.headers = {
+        "Content-Type": "application/json",
+      };
     }
 
-    return axios(request);
+    return this.axios(request);
   }
 }
 

--- a/src/Pinniped.js
+++ b/src/Pinniped.js
@@ -19,12 +19,16 @@ class Pinniped {
    * @param {string} baseURL - The base URL of the Pinniped server
    * @property {string} url - The base URL of the Pinniped server
    * @property {Auth} auth - An instance of the Auth class for handling authentication requests
+   * @property {AxiosInstance} axiosClient - An instance of the Axios client
    * @property {Data} db - An instance of the Data class for handling database requests
    * @property {function} sendRequest - A function for sending requests to the server
    */
   constructor(baseURL) {
     this.url = baseURL;
-    this.axios = axios.create({ withCredentials: true });
+    this.axiosClient = axios.create({
+      withCredentials: true,
+      headers: { Accept: "application/json" },
+    });
     this.auth = new Auth(this);
     this.db = new Data(this);
     console.log("Pinniped SDK initialized");
@@ -53,7 +57,7 @@ class Pinniped {
       };
     }
 
-    return this.axios(request);
+    return this.axiosClient(request);
   }
 }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -5,14 +5,15 @@ export default class Auth {
   static PATH = "/api/auth";
 
   /**
-   * @param {function} sendRequest - A function for sending requests to the server
-   * @property {string} url - The base URL concatenated with the authentication path
+   * @param {object} - Instance of the Pinniped SDK
+   * @property {string} url - The base URL concatenated with the Auth PATH
    * @property {function} sendRequest - A function for sending requests to the server
+   * @property {AxiosInstance} axiosClient - An instance of the Axios client
    */
-  constructor({ url, sendRequest, axios }) {
+  constructor({ url, sendRequest, axiosClient }) {
     this.url = `${url}${Auth.PATH}`;
     this.sendRequest = sendRequest;
-    this.axios = axios;
+    this.axiosClient = axiosClient;
   }
 
   /**

--- a/src/auth.js
+++ b/src/auth.js
@@ -9,9 +9,10 @@ export default class Auth {
    * @property {string} url - The base URL concatenated with the authentication path
    * @property {function} sendRequest - A function for sending requests to the server
    */
-  constructor(baseUrl, sendRequest) {
-    this.url = `${baseUrl}${Auth.PATH}`;
+  constructor({ url, sendRequest, axios }) {
+    this.url = `${url}${Auth.PATH}`;
     this.sendRequest = sendRequest;
+    this.axios = axios;
   }
 
   /**

--- a/src/data.js
+++ b/src/data.js
@@ -5,16 +5,15 @@ export default class Data {
   static PATH = "/api/tables";
 
   /**
-   * @param {string} baseUrl - The base URL of the Pinniped server
-   * @param {function} sendRequest - A function for sending requests to the server
-   * @property {string} url - The base URL concatenated with the data path
+   * @param {object} - Instance of the Pinniped SDK
+   * @property {string} url - The base URL concatenated with the Data PATH
    * @property {function} sendRequest - A function for sending requests to the server
-   * @memberof Data
+   * @property {AxiosInstance} axiosClient - An instance of the Axios client
    */
-  constructor({ url, sendRequest, axios }) {
+  constructor({ url, sendRequest, axiosClient }) {
     this.url = `${url}${Data.PATH}`;
     this.sendRequest = sendRequest;
-    this.axios = axios;
+    this.axiosClient = axiosClient;
   }
 
   /**

--- a/src/data.js
+++ b/src/data.js
@@ -11,9 +11,10 @@ export default class Data {
    * @property {function} sendRequest - A function for sending requests to the server
    * @memberof Data
    */
-  constructor(baseUrl, sendRequest) {
-    this.url = `${baseUrl}${Data.PATH}`;
+  constructor({ url, sendRequest, axios }) {
+    this.url = `${url}${Data.PATH}`;
     this.sendRequest = sendRequest;
+    this.axios = axios;
   }
 
   /**


### PR DESCRIPTION
### **Summary**

- Changed `Auth` and `Data` class constructors to accept an instance of the main `Pinniped` class as an argument and destructure the needed properties. 
- Added a new `axiosClient` property to the `Pinniped` class that uses the `axios.create` method to create a single axios instance with base configuration set for use by the `Auth` and `Data` class in their respective `sendRequest` invocations. 
- Updated the `sendRequest` method to conditionally add the `"Content-Type": "application/json"` when PUT, POST, or PATCH methods are used. 